### PR TITLE
Extension include annotation

### DIFF
--- a/WebContent/META-INF/MANIFEST.MF
+++ b/WebContent/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Class-Path: 
+

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,17 @@
 		</dependency>
 
 		<dependency>
+			<groupId>javax.enterprise</groupId>
+			<artifactId>cdi-api</artifactId>
+			<version>1.2</version>
+		</dependency>
+
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>3.0.1</version>
-			<scope>provided</scope>
+			<version>3.1.0</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.jboss.weld.servlet</groupId>
 			<artifactId>weld-servlet</artifactId>

--- a/src/main/java/br/com/javamagazine/artigo/IndexServlet.java
+++ b/src/main/java/br/com/javamagazine/artigo/IndexServlet.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.math.BigDecimal;
 
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -11,22 +12,35 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import br.com.javamagazine.pagamento.PagamentoBrasil;
+import br.com.javamagazine.pagamento.Pagamento;
 
 @WebServlet("/index")
 public class IndexServlet extends HttpServlet {
+
 	private static final long serialVersionUID = 1L;
 
-	@Inject
-	private PagamentoBrasil pagamento;
-	
+//	Esta injecao lanca Ambiguous Dependency ao startar o Tomcat pois o WELD encontra mais de um candidato para Injecao
+//	@Inject
+//	private Pagamento pagamento;
+
+//	Teriamos que avisar ao CDI em tempo de compilacao que queremos um tipo de pagamento especifico,
+//	mas eh exatamente o que gostariamos de evitar
+//	@Inject
+//	private PagamentoBrasil pagamento;
+
+	@Inject @Any
+	private Pagamento pagamento;
+
+	public IndexServlet() {
+	}
+
 	@Override
-	protected void doGet(HttpServletRequest request, HttpServletResponse response) 
+	protected void doGet(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException {
 		BigDecimal taxaImposto = pagamento.calcularTaxaImposto(BigDecimal.TEN);
-		
+
 		PrintWriter writer = response.getWriter();
 		writer.print(taxaImposto.toPlainString());
 	}
-	
+
 }

--- a/src/main/java/br/com/javamagazine/extension/CountryExpressionInterpreter.java
+++ b/src/main/java/br/com/javamagazine/extension/CountryExpressionInterpreter.java
@@ -1,0 +1,11 @@
+package br.com.javamagazine.extension;
+
+public class CountryExpressionInterpreter implements ExpressionInterpreter<String, Boolean> {
+
+	@Override
+	public Boolean interpret(String expression) {
+		String fromConfig = "AR";
+		return fromConfig.equals(expression);
+	}
+
+}

--- a/src/main/java/br/com/javamagazine/extension/CountryExtension.java
+++ b/src/main/java/br/com/javamagazine/extension/CountryExtension.java
@@ -1,0 +1,28 @@
+package br.com.javamagazine.extension;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+public class CountryExtension implements Extension {
+
+	@SuppressWarnings("rawtypes")
+	public void loadClassesToBeIncludedByCDI(@Observes ProcessAnnotatedType pat) {
+		AnnotatedType at = pat.getAnnotatedType();
+
+		boolean isIncludeAnnotationPresent = at.isAnnotationPresent(Include.class);
+
+		if (isIncludeAnnotationPresent) {
+			Include annotation = at.getAnnotation(Include.class);
+			String expression = annotation.onExpression();
+
+			CountryExpressionInterpreter interpreter = new CountryExpressionInterpreter();
+			Boolean expressionInterpreted = interpreter.interpret(expression);
+			if (!expressionInterpreted) {
+				pat.veto();
+			}
+		}
+	}
+
+}

--- a/src/main/java/br/com/javamagazine/extension/ExpressionInterpreter.java
+++ b/src/main/java/br/com/javamagazine/extension/ExpressionInterpreter.java
@@ -1,0 +1,7 @@
+package br.com.javamagazine.extension;
+
+public interface ExpressionInterpreter<E, R> {
+
+	public R interpret(E expression);
+
+}

--- a/src/main/java/br/com/javamagazine/extension/Include.java
+++ b/src/main/java/br/com/javamagazine/extension/Include.java
@@ -1,0 +1,21 @@
+package br.com.javamagazine.extension;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({FIELD, TYPE})
+@Qualifier
+public @interface Include {
+
+	String onExpression();
+
+	Class<? extends CountryExpressionInterpreter> interpretedBy();
+
+}

--- a/src/main/java/br/com/javamagazine/pagamento/PagamentoArgentina.java
+++ b/src/main/java/br/com/javamagazine/pagamento/PagamentoArgentina.java
@@ -5,12 +5,12 @@ import java.math.BigDecimal;
 import br.com.javamagazine.extension.CountryExpressionInterpreter;
 import br.com.javamagazine.extension.Include;
 
-@Include(onExpression = "VE", interpretedBy = CountryExpressionInterpreter.class)
-public class PagamentoVenezuela implements Pagamento {
+@Include(onExpression = "AR", interpretedBy = CountryExpressionInterpreter.class)
+public class PagamentoArgentina implements Pagamento {
 
 	@Override
 	public BigDecimal calcularTaxaImposto(BigDecimal valorPagamento) {
-		return new BigDecimal("2.75");
+		return new BigDecimal("4.75");
 	}
 
 	@Override

--- a/src/main/java/br/com/javamagazine/pagamento/PagamentoBrasil.java
+++ b/src/main/java/br/com/javamagazine/pagamento/PagamentoBrasil.java
@@ -2,6 +2,10 @@ package br.com.javamagazine.pagamento;
 
 import java.math.BigDecimal;
 
+import br.com.javamagazine.extension.CountryExpressionInterpreter;
+import br.com.javamagazine.extension.Include;
+
+@Include(onExpression = "BR", interpretedBy = CountryExpressionInterpreter.class)
 public class PagamentoBrasil implements Pagamento {
 
 	@Override
@@ -15,5 +19,5 @@ public class PagamentoBrasil implements Pagamento {
 		BigDecimal pagamento = valorPagamento.multiply(taxaImposto).add(valorPagamento);
 		System.out.println(pagamento.toPlainString());
 	}
-	
+
 }

--- a/src/main/resources/META-INF/beans.xml
+++ b/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans 	xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+							http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+		version="1.1" bean-discovery-mode="all">
+
+
+</beans>

--- a/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+br.com.javamagazine.extension.CountryExtension

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,7 @@
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-      version="3.0"> 
-	
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	version="3.0">
+
 	<display-name>Archetype Created Web Application</display-name>
 
 
@@ -14,5 +13,4 @@
 		<resource-env-ref-name>BeanManager</resource-env-ref-name>
 		<resource-env-ref-type>javax.enterprise.inject.spi.BeanManager</resource-env-ref-type>
 	</resource-env-ref>
-
 </web-app>


### PR DESCRIPTION
Expliquei por cima o @Include mas basicamente, ao subir o contexto do CDI, a Extension observa a fase ProcessAnnotatedType verifica todos os beans que possuem @Include e se tiver pegamos um Interpretador de Expressão (alguém que implementa a interface ExpressionInterpreter) e o interpretador verifica se o Bean é realmente passível de injeção e caso não seja ele ganha um Vetoed.
